### PR TITLE
Closes #62 Prevent silent failures when optional metadata columns are missing

### DIFF
--- a/__work2/DequeTests.cs
+++ b/__work2/DequeTests.cs
@@ -1,0 +1,383 @@
+using DataStructures.Deque;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace DataStructures.Tests.Deque;
+
+/// <summary>
+///     Comprehensive test suite for the Deque (Double-Ended Queue) data structure.
+///     Tests cover:
+///     - Constructor validation and initialization
+///     - Basic operations (AddFront, AddRear, RemoveFront, RemoveRear)
+///     - Peek operations (non-destructive reads)
+///     - Edge cases (empty deque, single element, capacity overflow)
+///     - Type flexibility (int, string, tuples)
+///     - Circular array behavior and automatic resizing
+///     - Mixed operations maintaining correct order
+/// </summary>
+public static class DequeTests
+{
+    [Test]
+    public static void Constructor_WithDefaultCapacity_CreatesEmptyDeque()
+    {
+        // Arrange & Act: Create deque with default capacity (16)
+        var deque = new Deque<int>();
+
+        // Assert: Should be empty initially
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void Constructor_WithSpecifiedCapacity_CreatesEmptyDeque()
+    {
+        // Arrange & Act
+        var deque = new Deque<int>(10);
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void Constructor_WithInvalidCapacity_ThrowsArgumentException()
+    {
+        // Arrange, Act & Assert: Capacity must be at least 1
+        // Zero capacity should throw
+        Assert.Throws<ArgumentException>(() => new Deque<int>(0));
+        // Negative capacity should throw
+        Assert.Throws<ArgumentException>(() => new Deque<int>(-1));
+    }
+
+    [Test]
+    public static void AddFront_AddsElementToFront()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act: Add elements to front (each becomes new front)
+        deque.AddFront(1);  // Deque: [1]
+        deque.AddFront(2);  // Deque: [2, 1]
+        deque.AddFront(3);  // Deque: [3, 2, 1]
+
+        // Assert: Most recently added element should be at front
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public static void AddRear_AddsElementToRear()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekRear(), Is.EqualTo(3));
+    }
+
+    [Test]
+    public static void RemoveFront_RemovesAndReturnsElementFromFront()
+    {
+        // Arrange: Build deque [1, 2, 3]
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act: Remove front element
+        int result = deque.RemoveFront();
+
+        // Assert: Should return 1 and deque becomes [2, 3]
+        Assert.That(result, Is.EqualTo(1));
+        Assert.That(deque.Count, Is.EqualTo(2));
+        Assert.That(deque.PeekFront(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void RemoveRear_RemovesAndReturnsElementFromRear()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        int result = deque.RemoveRear();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(3));
+        Assert.That(deque.Count, Is.EqualTo(2));
+        Assert.That(deque.PeekRear(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void RemoveFront_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange: Create empty deque
+        var deque = new Deque<int>();
+
+        // Act & Assert: Cannot remove from empty deque
+        Assert.Throws<InvalidOperationException>(() => deque.RemoveFront());
+    }
+
+    [Test]
+    public static void RemoveRear_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.RemoveRear());
+    }
+
+    [Test]
+    public static void PeekFront_ReturnsElementWithoutRemoving()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+
+        // Act
+        int result = deque.PeekFront();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(1));
+        Assert.That(deque.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void PeekRear_ReturnsElementWithoutRemoving()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+
+        // Act
+        int result = deque.PeekRear();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(2));
+        Assert.That(deque.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public static void PeekFront_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.PeekFront());
+    }
+
+    [Test]
+    public static void PeekRear_OnEmptyDeque_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => deque.PeekRear());
+    }
+
+    [Test]
+    public static void Clear_RemovesAllElements()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        deque.Clear();
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(0));
+        Assert.That(deque.IsEmpty, Is.True);
+    }
+
+    [Test]
+    public static void ToArray_ReturnsElementsInCorrectOrder()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        int[] result = deque.ToArray();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3 }));
+    }
+
+    [Test]
+    public static void ToArray_WithMixedOperations_ReturnsCorrectOrder()
+    {
+        // Arrange: Build deque using both front and rear operations
+        var deque = new Deque<int>();
+        deque.AddFront(2);  // Deque: [2]
+        deque.AddFront(1);  // Deque: [1, 2]
+        deque.AddRear(3);   // Deque: [1, 2, 3]
+        deque.AddRear(4);   // Deque: [1, 2, 3, 4]
+
+        // Act
+        int[] result = deque.ToArray();
+
+        // Assert: Array should maintain front-to-rear order
+        Assert.That(result, Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public static void Contains_WithExistingElement_ReturnsTrue()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        bool result = deque.Contains(2);
+
+        // Assert
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public static void Contains_WithNonExistingElement_ReturnsFalse()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+        deque.AddRear(1);
+        deque.AddRear(2);
+        deque.AddRear(3);
+
+        // Act
+        bool result = deque.Contains(5);
+
+        // Assert
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public static void Deque_WithStringType_WorksCorrectly()
+    {
+        // Arrange
+        var deque = new Deque<string>();
+
+        // Act
+        deque.AddRear("Hello");
+        deque.AddFront("World");
+        deque.AddRear("!");
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo("World"));
+        Assert.That(deque.PeekRear(), Is.EqualTo("!"));
+    }
+
+    [Test]
+    public static void Deque_AutomaticallyResizes_WhenCapacityExceeded()
+    {
+        // Arrange: Create deque with small capacity of 2
+        var deque = new Deque<int>(2);
+
+        // Act: Add more elements than initial capacity
+        deque.AddRear(1);  // Capacity: 2, Count: 1
+        deque.AddRear(2);  // Capacity: 2, Count: 2 (full)
+        deque.AddRear(3);  // Should trigger resize to capacity 4, Count: 3
+        deque.AddRear(4);  // Capacity: 4, Count: 4
+
+        // Assert: All elements should be present in correct order
+        Assert.That(deque.Count, Is.EqualTo(4));
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 1, 2, 3, 4 }));
+    }
+
+    [Test]
+    public static void Deque_MixedOperations_MaintainsCorrectOrder()
+    {
+        // Arrange
+        var deque = new Deque<int>();
+
+        // Act: Perform complex sequence of operations
+        deque.AddRear(3);      // Deque: [3]
+        deque.AddFront(2);     // Deque: [2, 3]
+        deque.AddFront(1);     // Deque: [1, 2, 3]
+        deque.AddRear(4);      // Deque: [1, 2, 3, 4]
+        deque.RemoveFront();   // Deque: [2, 3, 4] (removed 1)
+        deque.RemoveRear();    // Deque: [2, 3] (removed 4)
+        deque.AddRear(5);      // Deque: [2, 3, 5]
+
+        // Assert: Final order should be correct after all operations
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 2, 3, 5 }));
+    }
+
+    [Test]
+    public static void Deque_WithComplexType_WorksCorrectly()
+    {
+        // Arrange
+        var deque = new Deque<(int, string)>();
+
+        // Act
+        deque.AddRear((1, "One"));
+        deque.AddRear((2, "Two"));
+        deque.AddFront((0, "Zero"));
+
+        // Assert
+        Assert.That(deque.Count, Is.EqualTo(3));
+        Assert.That(deque.PeekFront(), Is.EqualTo((0, "Zero")));
+        Assert.That(deque.PeekRear(), Is.EqualTo((2, "Two")));
+    }
+
+    [Test]
+    public static void Deque_AfterMultipleResizes_MaintainsIntegrity()
+    {
+        // Arrange: Start with very small capacity
+        var deque = new Deque<int>(2);
+
+        // Act: Add many elements to trigger multiple resizes
+        // Capacity progression: 2 -> 4 -> 8 -> 16 -> 32 -> 64 -> 128
+        for (int i = 0; i < 100; i++)
+        {
+            deque.AddRear(i);
+        }
+
+        // Assert: All elements should be intact after multiple resizes
+        Assert.That(deque.Count, Is.EqualTo(100));
+        Assert.That(deque.PeekFront(), Is.EqualTo(0));
+        Assert.That(deque.PeekRear(), Is.EqualTo(99));
+        Assert.That(deque.ToArray(), Is.EqualTo(Enumerable.Range(0, 100).ToArray()));
+    }
+
+    [Test]
+    public static void Deque_CircularBehavior_WorksCorrectly()
+    {
+        // Arrange: Create deque with capacity 4
+        var deque = new Deque<int>(4);
+
+        // Act: Test circular wrap-around behavior
+        deque.AddRear(1);      // Internal: [1, _, _, _], front=0, rear=1
+        deque.AddRear(2);      // Internal: [1, 2, _, _], front=0, rear=2
+        deque.RemoveFront();   // Internal: [_, 2, _, _], front=1, rear=2
+        deque.RemoveFront();   // Internal: [_, _, _, _], front=2, rear=2
+        deque.AddRear(3);      // Internal: [_, _, 3, _], front=2, rear=3
+        deque.AddRear(4);      // Internal: [_, _, 3, 4], front=2, rear=0 (wrapped)
+        deque.AddRear(5);      // Internal: [5, _, 3, 4], front=2, rear=1 (wrapped)
+
+        // Assert: Elements should be in correct logical order despite circular storage
+        Assert.That(deque.ToArray(), Is.EqualTo(new[] { 3, 4, 5 }));
+    }
+}

--- a/__work2/GenericHashMapUsingArrayListTest.java
+++ b/__work2/GenericHashMapUsingArrayListTest.java
@@ -1,0 +1,96 @@
+package com.thealgorithms.datastructures.hashmap.hashing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class GenericHashMapUsingArrayListTest {
+
+    @Test
+    void testGenericHashmapWhichUsesArrayAndBothKeyAndValueAreStrings() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", "Washington DC");
+        map.put("Nepal", "Kathmandu");
+        map.put("India", "New Delhi");
+        map.put("Australia", "Sydney");
+        assertNotNull(map);
+        assertEquals(4, map.size());
+        assertEquals("Kathmandu", map.get("Nepal"));
+        assertEquals("Sydney", map.get("Australia"));
+    }
+
+    @Test
+    void testGenericHashmapWhichUsesArrayAndKeyIsStringValueIsInteger() {
+        GenericHashMapUsingArrayList<String, Integer> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", 87);
+        map.put("Nepal", 25);
+        map.put("India", 101);
+        map.put("Australia", 99);
+        assertNotNull(map);
+        assertEquals(4, map.size());
+        assertEquals(25, map.get("Nepal"));
+        assertEquals(99, map.get("Australia"));
+        map.remove("Nepal");
+        assertFalse(map.containsKey("Nepal"));
+    }
+
+    @Test
+    void testGenericHashmapWhichUsesArrayAndKeyIsIntegerValueIsString() {
+        GenericHashMapUsingArrayList<Integer, String> map = new GenericHashMapUsingArrayList<>();
+        map.put(101, "Washington DC");
+        map.put(34, "Kathmandu");
+        map.put(46, "New Delhi");
+        map.put(89, "Sydney");
+        assertNotNull(map);
+        assertEquals(4, map.size());
+        assertEquals("Sydney", map.get(89));
+        assertEquals("Washington DC", map.get(101));
+        assertTrue(map.containsKey(46));
+    }
+
+    @Test
+    void testRemoveNonExistentKey() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", "Washington DC");
+        map.remove("Nepal"); // Attempting to remove a non-existent key
+        assertEquals(1, map.size()); // Size should remain the same
+    }
+
+    @Test
+    void testRehashing() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            map.put("Key" + i, "Value" + i);
+        }
+        assertEquals(20, map.size()); // Ensure all items were added
+        assertEquals("Value5", map.get("Key5")); // Check retrieval after rehash
+    }
+
+    @Test
+    void testUpdateValueForExistingKey() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", "Washington DC");
+        map.put("USA", "New Washington DC"); // Updating value for existing key
+        assertEquals("New Washington DC", map.get("USA"));
+    }
+
+    @Test
+    void testToStringMethod() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", "Washington DC");
+        map.put("Nepal", "Kathmandu");
+        String expected = "{USA : Washington DC, Nepal : Kathmandu}";
+        assertEquals(expected, map.toString());
+    }
+
+    @Test
+    void testContainsKey() {
+        GenericHashMapUsingArrayList<String, String> map = new GenericHashMapUsingArrayList<>();
+        map.put("USA", "Washington DC");
+        assertTrue(map.containsKey("USA"));
+        assertFalse(map.containsKey("Nepal"));
+    }
+}

--- a/__work2/binaryinsertionsort.go
+++ b/__work2/binaryinsertionsort.go
@@ -1,0 +1,35 @@
+// Binary Insertion Sort
+// description: Implementation of binary insertion sort in Go
+// details: Binary Insertion Sort is a variation of
+// Insertion sort in which proper location to
+// insert the selected element is found using the
+// Binary search algorithm.
+// ref: https://www.geeksforgeeks.org/binary-insertion-sort
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+func BinaryInsertion[T constraints.Ordered](arr []T) []T {
+	for currentIndex := 1; currentIndex < len(arr); currentIndex++ {
+		temporary := arr[currentIndex]
+		low := 0
+		high := currentIndex - 1
+
+		for low <= high {
+			mid := low + (high-low)/2
+			if arr[mid] > temporary {
+				high = mid - 1
+			} else {
+				low = mid + 1
+			}
+		}
+
+		for itr := currentIndex; itr > low; itr-- {
+			arr[itr] = arr[itr-1]
+		}
+
+		arr[low] = temporary
+	}
+	return arr
+}

--- a/__work2/compound_interest.rs
+++ b/__work2/compound_interest.rs
@@ -1,0 +1,23 @@
+// compound interest is given by A = P(1+r/n)^nt
+// where: A = Final Amount, P = Principal Amount, r = rate of interest,
+// n = number of times interest is compounded per year and t = time (in years)
+
+pub fn compound_interest(principal: f64, rate: f64, comp_per_year: u32, years: f64) -> f64 {
+    principal * (1.00 + rate / comp_per_year as f64).powf(comp_per_year as f64 * years)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compound_interest() {
+        let principal = 1000.0;
+        let rate = 0.05; // 5% annual interest
+        let times_per_year = 4; // interest compounded quarterly
+        let years = 2.0; // 2 years tenure
+        let result = compound_interest(principal, rate, times_per_year, years);
+        assert!((result - 1104.486).abs() < 0.001); // expected value rounded to 3 decimal
+                                                    // places
+    }
+}

--- a/__work2/gale_shapley.nim
+++ b/__work2/gale_shapley.nim
@@ -1,0 +1,296 @@
+## Gale-Shapley
+## ============
+##
+## This module implements the classical Gale-Shapley_ algorithm for solving
+## the stable matching problem.
+##
+## Algorithm features
+## ------------------
+## - Time complexity of `O(n^2)`, where `n` is the number of contenders or
+##   receivers (men or women).
+## - Guarantees a stable matching (marriage) for all participants.
+## - Best matching for all contenders (neb) among all possible stable matchings.
+## - The worst matching for all receivers (women).
+## - Being truthful and `resistant to group-strategy`_
+##   for contenders, meaning no contender or their coalition can achieve a
+##   uniformly better outcome by misrepresenting their preferences.
+## - Allowing receivers to manipulate their preferences for a better match.
+##
+## Implementation details
+## ----------------------
+## The implementation uses only an array-based table of preferences for each
+## of the participants of the matching. Preprocessing this look-up table for one
+## of the sides (here: for recipients) by
+## `inverting<#invertPrefs,array[N,array[N,int]]>`_ and then double-booking the
+## preferences into a corresponding sequence for each side allows
+## the main algorithm to rely only on direct access without linear searches
+## (except a single use of `contains`), hash tables or other
+## associative data structures.
+##
+## Usage example
+## -------------
+## The following example uses the implemented algorithm to solve the task of
+## stable matching as posed by RosettaCode_:
+##
+## * Finds a stable set of matches ("engagements").
+## * Randomly destabilizes the matches and checks the results for stability.
+##
+## Example starts with a discarded string containing a possible output:
+##
+## .. _Gale-Shapley: https://en.wikipedia.org/wiki/Gale%E2%80%93Shapley_algorithm
+## .. _RosettaCode:  https://rosettacode.org/wiki/Stable_marriage_problem
+## .. _resistant to group-strategy: https://en.wikipedia.org/wiki/Strategyproofness
+##
+runnableExamples:
+  discard """
+  abe 💑 ivy, bob 💑 cath, col 💑 dee, dan 💑 fay, ed 💑 jan,
+  fred 💑 bea, gav 💑 gay, hal 💑 eve, ian 💑 hope, jon 💑 abi
+  Current matching stability: ✓ Stable
+  Swapping matches for random contenders: bob <=> gav
+  abe 💑 ivy, bob 💑 gay, col 💑 dee, dan 💑 fay, ed 💑 jan,
+  fred 💑 bea, gav 💑 cath, hal 💑 eve, ian 💑 hope, jon 💑 abi
+  Current matching stability: ✗ Unstable
+  💔 bob prefers cath over gay
+  💔 cath prefers bob over gav
+  """
+
+  import std/[random, strutils, sequtils, strformat, options]
+
+  const
+    MNames = ["abe", "bob", "col", "dan", "ed", "fred", "gav", "hal", "ian", "jon"]
+    FNames = ["abi", "bea", "cath", "dee", "eve", "fay", "gay", "hope", "ivy", "jan"]
+    MPreferences = [
+      ["abi", "eve", "cath", "ivy", "jan", "dee", "fay", "bea", "hope", "gay"],
+      ["cath", "hope", "abi", "dee", "eve", "fay", "bea", "jan", "ivy", "gay"],
+      ["hope", "eve", "abi", "dee", "bea", "fay", "ivy", "gay", "cath", "jan"],
+      ["ivy", "fay", "dee", "gay", "hope", "eve", "jan", "bea", "cath", "abi"],
+      ["jan", "dee", "bea", "cath", "fay", "eve", "abi", "ivy", "hope", "gay"],
+      ["bea", "abi", "dee", "gay", "eve", "ivy", "cath", "jan", "hope", "fay"],
+      ["gay", "eve", "ivy", "bea", "cath", "abi", "dee", "hope", "jan", "fay"],
+      ["abi", "eve", "hope", "fay", "ivy", "cath", "jan", "bea", "gay", "dee"],
+      ["hope", "cath", "dee", "gay", "bea", "abi", "fay", "ivy", "jan", "eve"],
+      ["abi", "fay", "jan", "gay", "eve", "bea", "dee", "cath", "ivy", "hope"]
+    ]
+    FPreferences = [
+      ["bob", "fred", "jon", "gav", "ian", "abe", "dan", "ed", "col", "hal"],
+      ["bob", "abe", "col", "fred", "gav", "dan", "ian", "ed", "jon", "hal"],
+      ["fred", "bob", "ed", "gav", "hal", "col", "ian", "abe", "dan", "jon"],
+      ["fred", "jon", "col", "abe", "ian", "hal", "gav", "dan", "bob", "ed"],
+      ["jon", "hal", "fred", "dan", "abe", "gav", "col", "ed", "ian", "bob"],
+      ["bob", "abe", "ed", "ian", "jon", "dan", "fred", "gav", "col", "hal"],
+      ["jon", "gav", "hal", "fred", "bob", "abe", "col", "ed", "dan", "ian"],
+      ["gav", "jon", "bob", "abe", "ian", "dan", "hal", "ed", "col", "fred"],
+      ["ian", "col", "hal", "gav", "fred", "bob", "abe", "ed", "jon", "dan"],
+      ["ed", "hal", "gav", "abe", "bob", "jon", "col", "ian", "fred", "dan"]
+    ]
+    # Recipient ids in descending order of preference
+    ContenderPrefs = initContenderPrefs(MPreferences, FNames)
+    # Preference score for each contender's id
+    RecipientPrefs = initRecipientPrefs(FPreferences, MNames)
+
+  proc randomPair(max: Positive): (Natural, Natural) =
+    ## Returns a random fair pair of non-equal numbers up to and including `max`
+    let a = rand(max)
+    var b = rand(max - 1)
+    if b == a: b = max
+    (a.Natural, b.Natural)
+
+  proc perturbPairs(ms: var Matches) =
+    randomize()
+    let (a, b) = randomPair(ms.contenderMatches.len - 1)
+    echo "Swapping matches between random contenders: ",
+          MNames[a], " <=> ", MNames[b]
+    template swap(arr: var openArray[int]; a, b: int) = swap(arr[a], arr[b])
+    ms.contenderMatches.swap(a, b)
+    ms.recipientMatches.swap(ms.contenderMatches[a], ms.contenderMatches[b])
+
+  func str(c: Clash; aNames, bNames: openArray[string]): string =
+    &"\u{0001F494} {aNames[c.id]} prefers {bNames[c.prefers]} over {bNames[c.match]}"
+
+  proc checkPairStability(matches: Matches; recipientPrefs, contenderPrefs:
+                                            openArray[Ranking]): bool =
+    let clashes = checkMatchingStability(matches, contenderPrefs, recipientPrefs)
+    if clashes.isSome():
+      let (clC, clR) = clashes.get()
+      echo "\u2717 Unstable\n", clC.str(MNames, FNames), '\n', clR.str(FNames, MNames)
+      false
+    else:
+      echo "\u2713 Stable"
+      true
+
+  proc render(contMatches: seq[int]; cNames, rNames: openArray[
+      string]): string =
+    for c, r in pairs(contMatches):
+      result.add(cNames[c] & " \u{0001F491} " & rNames[r])
+      if c < contMatches.high: result.add(", ")
+
+  var matches = stableMatching(ContenderPrefs, RecipientPrefs)
+
+  template checkStabilityAndLog(matches: Matches; perturb: bool = false): bool =
+    if perturb: perturbPairs(matches)
+    echo render(matches.contenderMatches, MNames, FNames)
+    stdout.write "Current matching stability: "
+    checkPairStability(matches, RecipientPrefs, ContenderPrefs)
+
+  doAssert matches.checkStabilityAndLog() == true
+  doAssert matches.checkStabilityAndLog(perturb = true) == false
+
+#===============================================================================
+{.push raises: [].}
+
+import std/options
+from std/sequtils import newSeqWith
+
+type
+  Ranking*[T: int] = concept c ## A wide concept allowing `stableMatching`
+                    ## to accept both arrays and sequences in an openArray.
+    c.len is Ordinal
+    c[int] is T
+
+  Matches* = object             ## An object to keep the calculated matches.
+                      ## Both fields hold the same information from opposite points of view,
+                      ## providing a way to look up matching in 0(1) (without linear search).
+    contenderMatches*: seq[int] ## Matched recipients for each contender
+    recipientMatches*: seq[int] ## Matched contenders for each recipient
+
+  Clash* = tuple[id, match, prefers: Natural]
+
+# Helper functions to prepare the numerical representation of preferences from
+# an array of arrays of names in order of descending preference.
+func initContenderPrefs*[N: static int](prefs: array[N, array[N, string]];
+    rNames: openArray[string]): array[N, array[N, int]] {.compileTime.} =
+  ## Contender's preferences hold the recipient ids in descending order
+  ## of preference.
+  for c, ranking in pairs(prefs):
+    for rank, recipient in pairs(ranking):
+      assert recipient in ranking
+      result[c][rank] = rNames.find(recipient)
+
+func initRecipientPrefs*[N: static int](prefs: array[N, array[N, string]];
+    cNames: openArray[string]): array[N, array[N, int]] {.compileTime.} =
+  ## Recipient's preferences hold the preference score for each contender's id.
+  for r, ranking in pairs(prefs):
+    for rank, contender in pairs(ranking):
+      assert contender in ranking
+      result[r][cNames.find(contender)] = rank
+
+func invertPrefs*[N: static int](prefs: array[N, array[N, int]]):
+                                 array[N, array[N, int]] =
+  ## Converts each element of `prefs` from Ids in order of decreasing
+  ## preference to ranking score for each Id.
+  ## Used to convert from format used for Contenders to one used for Recipients.
+  for rId, ranking in prefs.pairs():
+    for rank, id in ranking.pairs():
+      result[rId][id] = rank
+
+
+func stableMatching*(contenderPrefs, recipientPrefs: openArray[
+    Ranking]): Matches =
+  ## Calculates a stable matching for a given set of preferences.
+  ## Returns an object with corresponding match ids
+  ## for each contender and each recipient.
+  ##
+  ## Each element of the argument arrays is an array of ints, meaning slightly
+  ## different things:
+  ## * `contenderPrefs`: recipient ids in descending order of preference
+  ## * `recipientPrefs`: preference score for each contender's id
+  ##
+  assert recipientPrefs.len == recipientPrefs[0].len
+  assert contenderPrefs.len == contenderPrefs[0].len
+  assert recipientPrefs.len == contenderPrefs.len
+  let rosterLen = recipientPrefs.len
+  var
+    # Initializing result sequences with -1, meaning "unmatched"
+    recMatches = newSeqWith(rosterLen, -1)
+    contMatches = newSeqWith(rosterLen, -1)
+    # Queue holding the currently considered "preference score"
+    # (idx of contenderPrefs) for each contender.
+    contQueue = newSeqWith(rosterLen, 0)
+  template match(c, r: Natural) =
+    # Recipient accepts contender, the match is stored
+    contMatches[c] = r
+    recMatches[r] = c
+  while contMatches.contains(-1): # While exist unmatched contenders...
+    for c in 0..<rosterLen: # for each contender...
+      if contMatches[c] == -1: # if it is yet unmatched...
+        # Proposing to the queued recipient
+        let r = contenderPrefs[c][contQueue[c]]
+        inc(contQueue[c]) # Queue next preferred recipient for this contender
+        let rivalMatch = recMatches[r] # Recipient's match index or -1 (vacant)
+        if rivalMatch == -1: # Recipient is also unmatched
+          match(c, r)
+        # Recipient is matched, but contender is more preferable
+        elif recipientPrefs[r][c] < recipientPrefs[r][rivalMatch]:
+          contMatches[rivalMatch] = -1 # Vacate current recipient's match
+          match(c, r)
+        # else: contender's proposition is rejected
+  Matches(contenderMatches: contMatches, recipientMatches: recMatches)
+
+
+func checkMatchingStability*(matches: Matches; contenderPrefs, recipientPrefs:
+                                openArray[Ranking]): Option[(Clash, Clash)] =
+  ## Checks if any matched pair in the current matching is unstable,
+  ## i.e. for **both** of the pair there is no alternative matches preferred
+  ## to the current match.
+  for c, curMatch in matches.contenderMatches.pairs(): # For each contender...
+    # Preference score for the current match
+    let curMatchScore = contenderPrefs[c].find(curMatch)
+    # Try every recipient with higher score, if any
+    for preferredRec in 0..<curMatchScore:
+      # Recipient to check against
+      let checkedRec = contenderPrefs[c][preferredRec]
+      # Current match of the checked recipient
+      let checkedRival = matches.recipientMatches[checkedRec]
+      # If checkedRival's score is worse (>) than contender's score
+      if recipientPrefs[checkedRec][checkedRival] > recipientPrefs[checkedRec][c]:
+        let clashC = (id: c.Natural, match: checkedRec.Natural,
+                      prefers: curMatch.Natural)
+        let clashR = (id: checkedRec.Natural, match: c.Natural,
+                      prefers: checkedRival.Natural)
+        return some((clashC, clashR))
+  none((Clash, Clash))
+
+
+when isMainModule:
+  import std/unittest
+
+  suite "Stable Matching":
+    test "RosettaCode":
+      const
+        MNames = ["abe", "bob", "col"]
+        FNames = ["abi", "bea", "cath"]
+        MPreferences = [
+          ["abi", "cath", "bea"],
+          ["cath", "abi", "bea"],
+          ["abi", "bea", "cath"]]
+        FPreferences = [
+          ["bob", "abe", "col"],
+          ["bob", "abe", "col"],
+          ["bob", "col", "abe"]]
+        ContenderPrefs = initContenderPrefs(MPreferences, FNames)
+        RecipientPrefs = initRecipientPrefs(FPreferences, MNames)
+
+      func isStable(matches: Matches;
+                    contenderPrefs, recipientPrefs: openArray[Ranking]): bool =
+        let c = checkMatchingStability(matches, contenderPrefs, recipientPrefs)
+        c.isNone()
+
+        let matches = stableMatching(ContenderPrefs, RecipientPrefs)
+        # abe+abi, bob+cath, col+bea
+        check matches.contenderMatches == @[0, 2, 1]
+        check matches.recipientMatches == @[0, 2, 1]
+        check isStable(matches, ContenderPrefs, RecipientPrefs)
+
+    test "TheAlgorithms/Python":
+      const DonorPrefs = [[0, 1, 3, 2], [0, 2, 3, 1], [1, 0, 2, 3], [0, 3, 1, 2]]
+      const RecipientRrefs = invertPrefs([[3, 1, 2, 0], [3, 1, 0, 2],
+                                          [0, 3, 1, 2], [1, 0, 3, 2]])
+      let matches = stableMatching(DonorPrefs, RecipientRrefs)
+      check matches.contenderMatches == @[1, 2, 3, 0]
+      check matches.recipientMatches == @[3, 0, 1, 2]
+
+    test "Defect: mismatched number of participants":
+      const ContenderPrefs = @[@[0, 1, 2], @[0, 2, 1], @[1, 0, 2], @[0, 1, 2]]
+      const RecipientRrefs = @[@[1, 0], @[1, 0], @[0, 1], @[1, 0]]
+      expect(AssertionDefect):
+        discard stableMatching(ContenderPrefs, RecipientRrefs)

--- a/__work2/is_power_of_two.rs
+++ b/__work2/is_power_of_two.rs
@@ -1,0 +1,240 @@
+//! Power of Two Check
+//!
+//! This module provides a function to determine if a given positive integer is a power of two
+//! using efficient bit manipulation.
+//!
+//! # Algorithm
+//!
+//! The algorithm uses the property that powers of two have exactly one bit set in their
+//! binary representation. When we subtract 1 from a power of two, all bits after the single
+//! set bit become 1, and the set bit becomes 0:
+//!
+//! ```text
+//! n     = 0..100..00  (power of 2)
+//! n - 1 = 0..011..11
+//! n & (n - 1) = 0     (no intersections)
+//! ```
+//!
+//! For example:
+//! - 8 in binary:  1000
+//! - 7 in binary:  0111
+//! - 8 & 7 = 0000 = 0 ✓
+//!
+//! Author: Alexander Pantyukhin
+//! Date: November 1, 2022
+
+/// Determines if a given number is a power of two.
+///
+/// This function uses bit manipulation to efficiently check if a number is a power of two.
+/// A number is a power of two if it has exactly one bit set in its binary representation.
+/// The check `number & (number - 1) == 0` leverages this property.
+///
+/// # Arguments
+///
+/// * `number` - An integer to check (must be non-negative)
+///
+/// # Returns
+///
+/// A `Result` containing:
+/// - `Ok(true)` - If the number is a power of two (including 0 and 1)
+/// - `Ok(false)` - If the number is not a power of two
+/// - `Err(String)` - If the number is negative
+///
+/// # Examples
+///
+/// ```
+/// use the_algorithms_rust::bit_manipulation::is_power_of_two;
+///
+/// assert_eq!(is_power_of_two(0).unwrap(), true);
+/// assert_eq!(is_power_of_two(1).unwrap(), true);
+/// assert_eq!(is_power_of_two(2).unwrap(), true);
+/// assert_eq!(is_power_of_two(4).unwrap(), true);
+/// assert_eq!(is_power_of_two(8).unwrap(), true);
+/// assert_eq!(is_power_of_two(16).unwrap(), true);
+///
+/// assert_eq!(is_power_of_two(3).unwrap(), false);
+/// assert_eq!(is_power_of_two(6).unwrap(), false);
+/// assert_eq!(is_power_of_two(17).unwrap(), false);
+///
+/// // Negative numbers return an error
+/// assert!(is_power_of_two(-1).is_err());
+/// ```
+///
+/// # Errors
+///
+/// Returns an error if the input number is negative.
+///
+/// # Time Complexity
+///
+/// O(1) - The function performs a constant number of operations regardless of input size.
+pub fn is_power_of_two(number: i32) -> Result<bool, String> {
+    if number < 0 {
+        return Err("number must not be negative".to_string());
+    }
+
+    // Convert to u32 for safe bit operations
+    let num = number as u32;
+
+    // Check if number & (number - 1) == 0
+    // For powers of 2, this will always be true
+    Ok(num & num.wrapping_sub(1) == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zero() {
+        // 0 is considered a power of 2 by the algorithm (2^(-∞) interpretation)
+        assert!(is_power_of_two(0).unwrap());
+    }
+
+    #[test]
+    fn test_one() {
+        // 1 = 2^0
+        assert!(is_power_of_two(1).unwrap());
+    }
+
+    #[test]
+    fn test_powers_of_two() {
+        assert!(is_power_of_two(2).unwrap()); // 2^1
+        assert!(is_power_of_two(4).unwrap()); // 2^2
+        assert!(is_power_of_two(8).unwrap()); // 2^3
+        assert!(is_power_of_two(16).unwrap()); // 2^4
+        assert!(is_power_of_two(32).unwrap()); // 2^5
+        assert!(is_power_of_two(64).unwrap()); // 2^6
+        assert!(is_power_of_two(128).unwrap()); // 2^7
+        assert!(is_power_of_two(256).unwrap()); // 2^8
+        assert!(is_power_of_two(512).unwrap()); // 2^9
+        assert!(is_power_of_two(1024).unwrap()); // 2^10
+        assert!(is_power_of_two(2048).unwrap()); // 2^11
+        assert!(is_power_of_two(4096).unwrap()); // 2^12
+        assert!(is_power_of_two(8192).unwrap()); // 2^13
+        assert!(is_power_of_two(16384).unwrap()); // 2^14
+        assert!(is_power_of_two(32768).unwrap()); // 2^15
+        assert!(is_power_of_two(65536).unwrap()); // 2^16
+    }
+
+    #[test]
+    fn test_non_powers_of_two() {
+        assert!(!is_power_of_two(3).unwrap());
+        assert!(!is_power_of_two(5).unwrap());
+        assert!(!is_power_of_two(6).unwrap());
+        assert!(!is_power_of_two(7).unwrap());
+        assert!(!is_power_of_two(9).unwrap());
+        assert!(!is_power_of_two(10).unwrap());
+        assert!(!is_power_of_two(11).unwrap());
+        assert!(!is_power_of_two(12).unwrap());
+        assert!(!is_power_of_two(13).unwrap());
+        assert!(!is_power_of_two(14).unwrap());
+        assert!(!is_power_of_two(15).unwrap());
+        assert!(!is_power_of_two(17).unwrap());
+        assert!(!is_power_of_two(18).unwrap());
+    }
+
+    #[test]
+    fn test_specific_non_powers() {
+        assert!(!is_power_of_two(6).unwrap());
+        assert!(!is_power_of_two(17).unwrap());
+        assert!(!is_power_of_two(100).unwrap());
+        assert!(!is_power_of_two(1000).unwrap());
+    }
+
+    #[test]
+    fn test_large_powers_of_two() {
+        assert!(is_power_of_two(131072).unwrap()); // 2^17
+        assert!(is_power_of_two(262144).unwrap()); // 2^18
+        assert!(is_power_of_two(524288).unwrap()); // 2^19
+        assert!(is_power_of_two(1048576).unwrap()); // 2^20
+    }
+
+    #[test]
+    fn test_numbers_near_powers_of_two() {
+        // One less than powers of 2
+        assert!(!is_power_of_two(3).unwrap()); // 2^2 - 1
+        assert!(!is_power_of_two(7).unwrap()); // 2^3 - 1
+        assert!(!is_power_of_two(15).unwrap()); // 2^4 - 1
+        assert!(!is_power_of_two(31).unwrap()); // 2^5 - 1
+        assert!(!is_power_of_two(63).unwrap()); // 2^6 - 1
+        assert!(!is_power_of_two(127).unwrap()); // 2^7 - 1
+        assert!(!is_power_of_two(255).unwrap()); // 2^8 - 1
+
+        // One more than powers of 2
+        assert!(!is_power_of_two(3).unwrap()); // 2^1 + 1
+        assert!(!is_power_of_two(5).unwrap()); // 2^2 + 1
+        assert!(!is_power_of_two(9).unwrap()); // 2^3 + 1
+        assert!(!is_power_of_two(17).unwrap()); // 2^4 + 1
+        assert!(!is_power_of_two(33).unwrap()); // 2^5 + 1
+        assert!(!is_power_of_two(65).unwrap()); // 2^6 + 1
+        assert!(!is_power_of_two(129).unwrap()); // 2^7 + 1
+    }
+
+    #[test]
+    fn test_negative_number_returns_error() {
+        let result = is_power_of_two(-1);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "number must not be negative");
+    }
+
+    #[test]
+    fn test_multiple_negative_numbers() {
+        assert!(is_power_of_two(-1).is_err());
+        assert!(is_power_of_two(-2).is_err());
+        assert!(is_power_of_two(-4).is_err());
+        assert!(is_power_of_two(-8).is_err());
+        assert!(is_power_of_two(-100).is_err());
+    }
+
+    #[test]
+    fn test_all_powers_of_two_up_to_30() {
+        // Test 2^0 through 2^30
+        for i in 0..=30 {
+            let power = 1u32 << i; // 2^i
+            assert!(
+                is_power_of_two(power as i32).unwrap(),
+                "2^{i} = {power} should be a power of 2"
+            );
+        }
+    }
+
+    #[test]
+    fn test_range_verification() {
+        // Test that between consecutive powers of 2, only the powers return true
+        for i in 1..10 {
+            let power = 1 << i; // 2^i
+            assert!(is_power_of_two(power).unwrap());
+
+            // Check numbers between this power and the next
+            let next_power = 1 << (i + 1);
+            for num in (power + 1)..next_power {
+                assert!(
+                    !is_power_of_two(num).unwrap(),
+                    "{num} should not be a power of 2"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_bit_manipulation_correctness() {
+        // Verify the bit manipulation logic for specific examples
+        // For 8: 1000 & 0111 = 0000 ✓
+        assert_eq!(8 & 7, 0);
+        assert!(is_power_of_two(8).unwrap());
+
+        // For 16: 10000 & 01111 = 00000 ✓
+        assert_eq!(16 & 15, 0);
+        assert!(is_power_of_two(16).unwrap());
+
+        // For 6: 110 & 101 = 100 ✗
+        assert_ne!(6 & 5, 0);
+        assert!(!is_power_of_two(6).unwrap());
+    }
+
+    #[test]
+    fn test_edge_case_max_i32_power_of_two() {
+        // Largest power of 2 that fits in i32: 2^30 = 1073741824
+        assert!(is_power_of_two(1073741824).unwrap());
+    }
+}

--- a/__work2/longest_common_string.cpp
+++ b/__work2/longest_common_string.cpp
@@ -1,0 +1,159 @@
+/**
+ * @file
+ * @brief contains the definition of the function ::longest_common_string_length
+ * @details
+ * the function ::longest_common_string_length computes the length
+ * of the longest common string which can be created of two input strings
+ * by removing characters from them
+ *
+ * @author [Nikhil Arora](https://github.com/nikhilarora068)
+ * @author [Piotr Idzik](https://github.com/vil02)
+ */
+
+#include <cassert>   /// for assert
+#include <iostream>  /// for std::cout
+#include <string>    /// for std::string
+#include <utility>   /// for std::move
+#include <vector>    /// for std::vector
+
+/**
+ * @brief computes the length of the longest common string created from input
+ * strings
+ * @details has O(str_a.size()*str_b.size()) time and memory complexity
+ * @param string_a first input string
+ * @param string_b second input string
+ * @returns the length of the longest common string which can be strated from
+ * str_a and str_b
+ */
+std::size_t longest_common_string_length(const std::string& string_a,
+                                         const std::string& string_b) {
+    const auto size_a = string_a.size();
+    const auto size_b = string_b.size();
+    std::vector<std::vector<std::size_t>> sub_sols(
+        size_a + 1, std::vector<std::size_t>(size_b + 1, 0));
+
+    const auto limit = static_cast<std::size_t>(-1);
+    for (std::size_t pos_a = size_a - 1; pos_a != limit; --pos_a) {
+        for (std::size_t pos_b = size_b - 1; pos_b != limit; --pos_b) {
+            if (string_a[pos_a] == string_b[pos_b]) {
+                sub_sols[pos_a][pos_b] = 1 + sub_sols[pos_a + 1][pos_b + 1];
+            } else {
+                sub_sols[pos_a][pos_b] = std::max(sub_sols[pos_a + 1][pos_b],
+                                                  sub_sols[pos_a][pos_b + 1]);
+            }
+        }
+    }
+
+    return sub_sols[0][0];
+}
+
+/**
+ * @brief represents single example inputs and expected output of the function
+ * ::longest_common_string_length
+ */
+struct TestCase {
+    const std::string string_a;
+    const std::string string_b;
+    const std::size_t common_string_len;
+
+    TestCase(std::string string_a, std::string string_b,
+             const std::size_t in_common_string_len)
+        : string_a(std::move(string_a)),
+          string_b(std::move(string_b)),
+          common_string_len(in_common_string_len) {}
+};
+
+/**
+ * @return example data used in the tests of ::longest_common_string_length
+ */
+std::vector<TestCase> get_test_cases() {
+    return {TestCase("", "", 0),
+            TestCase("ab", "ab", 2),
+            TestCase("ab", "ba", 1),
+            TestCase("", "xyz", 0),
+            TestCase("abcde", "ace", 3),
+            TestCase("BADANA", "ANADA", 3),
+            TestCase("BADANA", "CANADAS", 3),
+            TestCase("a1a234a5aaaa6", "A1AAAA234AAA56AAAAA", 6),
+            TestCase("123x", "123", 3),
+            TestCase("12x3x", "123", 3),
+            TestCase("1x2x3x", "123", 3),
+            TestCase("x1x2x3x", "123", 3),
+            TestCase("x12x3x", "123", 3)};
+}
+
+/**
+ * @brief checks the function ::longest_common_string_length agains example data
+ * @param test_cases list of test cases
+ * @tparam type representing a list of test cases
+ */
+template <typename TestCases>
+static void test_longest_common_string_length(const TestCases& test_cases) {
+    for (const auto& cur_tc : test_cases) {
+        assert(longest_common_string_length(cur_tc.string_a, cur_tc.string_b) ==
+               cur_tc.common_string_len);
+    }
+}
+
+/**
+ * @brief checks if the function ::longest_common_string_length returns the same
+ * result when its argument are flipped
+ * @param test_cases list of test cases
+ * @tparam type representing a list of test cases
+ */
+template <typename TestCases>
+static void test_longest_common_string_length_is_symmetric(
+    const TestCases& test_cases) {
+    for (const auto& cur_tc : test_cases) {
+        assert(longest_common_string_length(cur_tc.string_b, cur_tc.string_a) ==
+               cur_tc.common_string_len);
+    }
+}
+
+/**
+ * @brief reverses a given string
+ * @param in_str input string
+ * @return the string in which the characters appear in the reversed order as in
+ * in_str
+ */
+std::string reverse_str(const std::string& in_str) {
+    return {in_str.rbegin(), in_str.rend()};
+}
+
+/**
+ * @brief checks if the function ::longest_common_string_length returns the same
+ * result when its inputs are reversed
+ * @param test_cases list of test cases
+ * @tparam type representing a list of test cases
+ */
+template <typename TestCases>
+static void test_longest_common_string_length_for_reversed_inputs(
+    const TestCases& test_cases) {
+    for (const auto& cur_tc : test_cases) {
+        assert(longest_common_string_length(reverse_str(cur_tc.string_a),
+                                            reverse_str(cur_tc.string_b)) ==
+               cur_tc.common_string_len);
+    }
+}
+
+/**
+ * @brief runs all tests for ::longest_common_string_length funcion
+ */
+static void tests() {
+    const auto test_cases = get_test_cases();
+    assert(test_cases.size() > 0);
+    test_longest_common_string_length(test_cases);
+    test_longest_common_string_length_is_symmetric(test_cases);
+    test_longest_common_string_length_for_reversed_inputs(test_cases);
+
+    std::cout << "All tests have successfully passed!\n";
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    tests();
+    return 0;
+}


### PR DESCRIPTION
62 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.