### PR TITLE
Closes #65 Add rationale for declining backward compatibility support

### DIFF
--- a/__frag2/DijkstraOptimizedAlgorithm.java
+++ b/__frag2/DijkstraOptimizedAlgorithm.java
@@ -1,0 +1,66 @@
+package com.thealgorithms.datastructures.graphs;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Dijkstra's algorithm for finding the shortest path from a single source vertex to all other vertices in a graph.
+ */
+public class DijkstraOptimizedAlgorithm {
+
+    private final int vertexCount;
+
+    /**
+     * Constructs a Dijkstra object with the given number of vertices.
+     *
+     * @param vertexCount The number of vertices in the graph.
+     */
+    public DijkstraOptimizedAlgorithm(int vertexCount) {
+        this.vertexCount = vertexCount;
+    }
+
+    /**
+     * Executes Dijkstra's algorithm on the provided graph to find the shortest paths from the source vertex to all other vertices.
+     *
+     * The graph is represented as an adjacency matrix where {@code graph[i][j]} represents the weight of the edge from vertex {@code i}
+     * to vertex {@code j}. A value of 0 indicates no edge exists between the vertices.
+     *
+     * @param graph The graph represented as an adjacency matrix.
+     * @param source The source vertex.
+     * @return An array where the value at each index {@code i} represents the shortest distance from the source vertex to vertex {@code i}.
+     * @throws IllegalArgumentException if the source vertex is out of range.
+     */
+    public int[] run(int[][] graph, int source) {
+        if (source < 0 || source >= vertexCount) {
+            throw new IllegalArgumentException("Incorrect source");
+        }
+
+        int[] distances = new int[vertexCount];
+        boolean[] processed = new boolean[vertexCount];
+        Set<Pair<Integer, Integer>> unprocessed = new TreeSet<>();
+
+        Arrays.fill(distances, Integer.MAX_VALUE);
+        Arrays.fill(processed, false);
+        distances[source] = 0;
+        unprocessed.add(Pair.of(0, source));
+
+        while (!unprocessed.isEmpty()) {
+            Pair<Integer, Integer> distanceAndU = unprocessed.iterator().next();
+            unprocessed.remove(distanceAndU);
+            int u = distanceAndU.getRight();
+            processed[u] = true;
+
+            for (int v = 0; v < vertexCount; v++) {
+                if (!processed[v] && graph[u][v] != 0 && distances[u] != Integer.MAX_VALUE && distances[u] + graph[u][v] < distances[v]) {
+                    unprocessed.remove(Pair.of(distances[v], v));
+                    distances[v] = distances[u] + graph[u][v];
+                    unprocessed.add(Pair.of(distances[v], v));
+                }
+            }
+        }
+
+        return distances;
+    }
+}

--- a/__frag2/Implementing_auto_completing_features_using_trie.java
+++ b/__frag2/Implementing_auto_completing_features_using_trie.java
@@ -1,0 +1,170 @@
+package com.thealgorithms.others;
+
+// Java Program to implement Auto-Complete
+// Feature using Trie
+class Trieac {
+
+    // Alphabet size (# of symbols)
+    public static final int ALPHABET_SIZE = 26;
+
+    // Trie node
+    static class TrieNode {
+
+        TrieNode[] children = new TrieNode[ALPHABET_SIZE];
+
+        // isWordEnd is true if the node represents
+        // end of a word
+        boolean isWordEnd;
+    }
+
+    // Returns new trie node (initialized to NULLs)
+    static TrieNode getNode() {
+        TrieNode pNode = new TrieNode();
+        pNode.isWordEnd = false;
+
+        for (int i = 0; i < ALPHABET_SIZE; i++) {
+            pNode.children[i] = null;
+        }
+
+        return pNode;
+    }
+
+    // If not present, inserts key into trie. If the
+    // key is prefix of trie node, just marks leaf node
+    static void insert(TrieNode root, final String key) {
+        TrieNode pCrawl = root;
+
+        for (int level = 0; level < key.length(); level++) {
+            int index = (key.charAt(level) - 'a');
+            if (pCrawl.children[index] == null) {
+                pCrawl.children[index] = getNode();
+            }
+            pCrawl = pCrawl.children[index];
+        }
+
+        // mark last node as leaf
+        pCrawl.isWordEnd = true;
+    }
+
+    // Returns true if key presents in trie, else false
+    boolean search(TrieNode root, final String key) {
+        int length = key.length();
+        TrieNode pCrawl = root;
+
+        for (int level = 0; level < length; level++) {
+            int index = (key.charAt(level) - 'a');
+
+            if (pCrawl.children[index] == null) {
+                pCrawl = pCrawl.children[index];
+            }
+        }
+
+        return (pCrawl != null && pCrawl.isWordEnd);
+    }
+
+    // Returns 0 if current node has a child
+    // If all children are NULL, return 1.
+    static boolean isLastNode(TrieNode root) {
+        for (int i = 0; i < ALPHABET_SIZE; i++) {
+            if (root.children[i] != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Recursive function to print auto-suggestions
+    // for given node.
+    static void suggestionsRec(TrieNode root, String currPrefix) {
+        // found a string in Trie with the given prefix
+        if (root.isWordEnd) {
+            System.out.println(currPrefix);
+        }
+
+        // All children struct node pointers are NULL
+        if (isLastNode(root)) {
+            return;
+        }
+
+        for (int i = 0; i < ALPHABET_SIZE; i++) {
+            if (root.children[i] != null) {
+                // append current character to currPrefix string
+                currPrefix += (char) (97 + i);
+
+                // recur over the rest
+                suggestionsRec(root.children[i], currPrefix);
+            }
+        }
+    }
+
+    // Function  to print suggestions for
+    // given query prefix.
+    static int printAutoSuggestions(TrieNode root, final String query) {
+        TrieNode pCrawl = root;
+
+        // Check if prefix is present and find the
+        // the node (of last level) with last character
+        // of given string.
+        int level;
+        int n = query.length();
+
+        for (level = 0; level < n; level++) {
+            int index = (query.charAt(level) - 'a');
+
+            // no string in the Trie has this prefix
+            if (pCrawl.children[index] == null) {
+                return 0;
+            }
+
+            pCrawl = pCrawl.children[index];
+        }
+
+        // If prefix is present as a word.
+        boolean isWord = (pCrawl.isWordEnd);
+
+        // If prefix is last node of tree (has no
+        // children)
+        boolean isLast = isLastNode(pCrawl);
+
+        // If prefix is present as a word, but
+        // there is no subtree below the last
+        // matching node.
+        if (isWord && isLast) {
+            System.out.println(query);
+            return -1;
+        }
+
+        // If there are nodes below the last
+        // matching character.
+        if (!isLast) {
+            String prefix = query;
+            suggestionsRec(pCrawl, prefix);
+            return 1;
+        }
+
+        return 0;
+    }
+
+    // Driver code
+    public static void main(String[] args) {
+        TrieNode root = getNode();
+        insert(root, "hello");
+        insert(root, "dog");
+        insert(root, "hell");
+        insert(root, "cat");
+        insert(root, "a");
+        insert(root, "hel");
+        insert(root, "help");
+        insert(root, "helps");
+        insert(root, "helping");
+        int comp = printAutoSuggestions(root, "hel");
+
+        if (comp == -1) {
+            System.out.println("No other strings found "
+                + "with this prefix\n");
+        } else if (comp == 0) {
+            System.out.println("No string found with"
+                + " this prefix\n");
+        }
+    }
+}

--- a/__frag2/arithmetic_progression.lua
+++ b/__frag2/arithmetic_progression.lua
@@ -1,0 +1,15 @@
+-- Based on the gaussian sum formula
+return function(
+	from, -- inclusive lower bound
+	to, -- inclusive upper bound
+	step -- step between values
+)
+	if from > to then
+		assert(step < 0, "empty interval")
+	end
+	step = step or 1
+	local count = math.floor((to - from) / step)
+	local last = from + count * step
+	-- sum of numbers from `from` to `to` with step `step`
+	return (count + 1) * (from + last) / 2
+end

--- a/__frag2/climbing_stairs.py
+++ b/__frag2/climbing_stairs.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+
+def climb_stairs(number_of_steps: int) -> int:
+    """
+    LeetCdoe No.70: Climbing Stairs
+    Distinct ways to climb a number_of_steps staircase where each time you can either
+    climb 1 or 2 steps.
+
+    Args:
+        number_of_steps: number of steps on the staircase
+
+    Returns:
+        Distinct ways to climb a number_of_steps staircase
+
+    Raises:
+        AssertionError: number_of_steps not positive integer
+
+    >>> climb_stairs(3)
+    3
+    >>> climb_stairs(1)
+    1
+    >>> climb_stairs(-7)  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+        ...
+    AssertionError: number_of_steps needs to be positive integer, your input -7
+    """
+    assert isinstance(number_of_steps, int) and number_of_steps > 0, (
+        f"number_of_steps needs to be positive integer, your input {number_of_steps}"
+    )
+    if number_of_steps == 1:
+        return 1
+    previous, current = 1, 1
+    for _ in range(number_of_steps - 1):
+        current, previous = current + previous, current
+    return current
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
65 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.