### PR TITLE
Closes #97 Deduplicate metric computation across evaluation stages

### DIFF
--- a/__sql6/FloodFillTest.java
+++ b/__sql6/FloodFillTest.java
@@ -1,0 +1,106 @@
+package com.thealgorithms.backtracking;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FloodFillTest {
+
+    @Test
+    void testForEmptyImage() {
+        int[][] image = {};
+        int[][] expected = {};
+
+        FloodFill.floodFill(image, 4, 5, 3, 2);
+        assertArrayEquals(expected, image);
+    }
+
+    @Test
+    void testForSingleElementImage() {
+        int[][] image = {{1}};
+        int[][] expected = {{3}};
+
+        FloodFill.floodFill(image, 0, 0, 3, 1);
+        assertArrayEquals(expected, image);
+    }
+
+    @Test
+    void testForImageOne() {
+        int[][] image = {
+            {0, 0, 0, 0, 0, 0, 0},
+            {0, 3, 3, 3, 3, 0, 0},
+            {0, 3, 1, 1, 5, 0, 0},
+            {0, 3, 1, 1, 5, 5, 3},
+            {0, 3, 5, 5, 1, 1, 3},
+            {0, 0, 0, 5, 1, 1, 3},
+            {0, 0, 0, 3, 3, 3, 3},
+        };
+
+        int[][] expected = {
+            {0, 0, 0, 0, 0, 0, 0},
+            {0, 3, 3, 3, 3, 0, 0},
+            {0, 3, 2, 2, 5, 0, 0},
+            {0, 3, 2, 2, 5, 5, 3},
+            {0, 3, 5, 5, 2, 2, 3},
+            {0, 0, 0, 5, 2, 2, 3},
+            {0, 0, 0, 3, 3, 3, 3},
+        };
+
+        FloodFill.floodFill(image, 2, 2, 2, 1);
+        assertArrayEquals(expected, image);
+    }
+
+    @Test
+    void testForImageTwo() {
+        int[][] image = {
+            {0, 0, 1, 1, 0, 0, 0},
+            {1, 1, 3, 3, 3, 0, 0},
+            {1, 3, 1, 1, 5, 0, 0},
+            {0, 3, 1, 1, 5, 5, 3},
+            {0, 3, 5, 5, 1, 1, 3},
+            {0, 0, 0, 5, 1, 1, 3},
+            {0, 0, 0, 1, 3, 1, 3},
+        };
+
+        int[][] expected = {
+            {0, 0, 2, 2, 0, 0, 0},
+            {2, 2, 3, 3, 3, 0, 0},
+            {2, 3, 2, 2, 5, 0, 0},
+            {0, 3, 2, 2, 5, 5, 3},
+            {0, 3, 5, 5, 2, 2, 3},
+            {0, 0, 0, 5, 2, 2, 3},
+            {0, 0, 0, 2, 3, 2, 3},
+        };
+
+        FloodFill.floodFill(image, 2, 2, 2, 1);
+        assertArrayEquals(expected, image);
+    }
+
+    @Test
+    void testForImageThree() {
+        int[][] image = {
+            {1, 1, 2, 3, 1, 1, 1},
+            {1, 0, 0, 1, 0, 0, 1},
+            {1, 1, 1, 0, 3, 1, 2},
+        };
+
+        int[][] expected = {
+            {4, 4, 2, 3, 4, 4, 4},
+            {4, 0, 0, 4, 0, 0, 4},
+            {4, 4, 4, 0, 3, 4, 2},
+        };
+
+        FloodFill.floodFill(image, 0, 1, 4, 1);
+        assertArrayEquals(expected, image);
+    }
+
+    @Test
+    void testForSameNewAndOldColor() {
+        int[][] image = {{1, 1, 2}, {1, 0, 0}, {1, 1, 1}};
+
+        int[][] expected = {{1, 1, 2}, {1, 0, 0}, {1, 1, 1}};
+
+        FloodFill.floodFill(image, 0, 1, 1, 1);
+        assertArrayEquals(expected, image);
+    }
+}

--- a/__sql6/QueueBasedStack.cs
+++ b/__sql6/QueueBasedStack.cs
@@ -1,0 +1,69 @@
+namespace DataStructures.Stack;
+
+public class QueueBasedStack<T>
+{
+    private readonly Queue<T> queue;
+
+    public QueueBasedStack() => queue = new Queue<T>();
+
+    /// <summary>
+    ///     Clears the stack.
+    /// </summary>
+    public void Clear() => queue.Clear();
+
+    public bool IsEmpty() => queue.Count == 0;
+
+    /// <summary>
+    ///     Adds an item on top of the stack.
+    /// </summary>
+    /// <param name="item">Item to be added on top of stack.</param>
+    public void Push(T item) => queue.Enqueue(item);
+
+    /// <summary>
+    ///     Removes an item from  top of the stack and returns it.
+    ///  </summary>
+    /// <returns>item on top of stack.</returns>
+    /// <exception cref="InvalidOperationException">Throw if stack is empty.</exception>
+    public T Pop()
+    {
+        if (IsEmpty())
+        {
+            throw new InvalidOperationException("The stack contains no items.");
+        }
+
+        for (int i = 0; i < queue.Count - 1; i++)
+        {
+            queue.Enqueue(queue.Dequeue());
+        }
+
+        return queue.Dequeue();
+    }
+
+    /// <summary>
+    ///     return an item from the top of the stack without removing it.
+    /// </summary>
+    /// <returns>item on top of the stack.</returns>
+    /// <exception cref="InvalidOperationException">Throw if stack is empty.</exception>
+    public T Peek()
+    {
+        if (IsEmpty())
+        {
+            throw new InvalidOperationException("The stack contains no items.");
+        }
+
+        for (int i = 0; i < queue.Count - 1; i++)
+        {
+            queue.Enqueue(queue.Dequeue());
+        }
+
+        var item = queue.Peek();
+        queue.Enqueue(queue.Dequeue());
+        return item;
+    }
+
+    /// <summary>
+    ///     returns the count of items on the stack.
+    /// </summary>
+    /// <returns>number of items on the stack.</returns>
+    public int Length() => queue.Count;
+}

--- a/__sql6/QuickSort.php
+++ b/__sql6/QuickSort.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Quick Sort
+ * Compare number in an array to the next number and sets to new array (greater than or less than)
+ *
+ * @param array $input array of random numbers
+ * @return array sorted array of numbers
+ */
+function quickSort(array $input)
+{
+    // Return nothing if input is empty
+    if (empty($input)) {
+        return [];
+    }
+
+    $lt = [];
+    $gt = [];
+    if (sizeof($input) < 2) {
+        return $input;
+    }
+
+    $key = key($input);
+    $shift = array_shift($input);
+    foreach ($input as $value) {
+        $value <= $shift ? $lt[] = $value : $gt[] = $value;
+    }
+
+    return array_merge(quickSort($lt), [$key => $shift], quickSort($gt));
+}

--- a/__sql6/SimpleSubCipherTest.java
+++ b/__sql6/SimpleSubCipherTest.java
@@ -1,0 +1,36 @@
+package com.thealgorithms.ciphers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleSubCipherTest {
+
+    SimpleSubCipher simpleSubCipher = new SimpleSubCipher();
+
+    @Test
+    void simpleSubCipherEncryptTest() {
+        // given
+        String text = "defend the east wall of the castle";
+        String cipherSmall = "phqgiumeaylnofdxjkrcvstzwb";
+
+        // when
+        String cipherText = simpleSubCipher.encode(text, cipherSmall);
+
+        // then
+        assertEquals("giuifg cei iprc tpnn du cei qprcni", cipherText);
+    }
+
+    @Test
+    void simpleSubCipherDecryptTest() {
+        // given
+        String encryptedText = "giuifg cei iprc tpnn du cei qprcni";
+        String cipherSmall = "phqgiumeaylnofdxjkrcvstzwb";
+
+        // when
+        String decryptedText = simpleSubCipher.decode(encryptedText, cipherSmall);
+
+        // then
+        assertEquals("defend the east wall of the castle", decryptedText);
+    }
+}

--- a/__sql6/circular_convolution.py
+++ b/__sql6/circular_convolution.py
@@ -1,0 +1,98 @@
+# https://en.wikipedia.org/wiki/Circular_convolution
+
+"""
+Circular convolution, also known as cyclic convolution,
+is a special case of periodic convolution, which is the convolution of two
+periodic functions that have the same period. Periodic convolution arises,
+for example, in the context of the discrete-time Fourier transform (DTFT).
+In particular, the DTFT of the product of two discrete sequences is the periodic
+convolution of the DTFTs of the individual sequences. And each DTFT is a periodic
+summation of a continuous Fourier transform function.
+
+Source: https://en.wikipedia.org/wiki/Circular_convolution
+"""
+
+import doctest
+from collections import deque
+
+import numpy as np
+
+
+class CircularConvolution:
+    """
+    This class stores the first and second signal and performs the circular convolution
+    """
+
+    def __init__(self) -> None:
+        """
+        First signal and second signal are stored as 1-D array
+        """
+
+        self.first_signal = [2, 1, 2, -1]
+        self.second_signal = [1, 2, 3, 4]
+
+    def circular_convolution(self) -> list[float]:
+        """
+        This function performs the circular convolution of the first and second signal
+        using matrix method
+
+        Usage:
+        >>> convolution = CircularConvolution()
+        >>> convolution.circular_convolution()
+        [10.0, 10.0, 6.0, 14.0]
+
+        >>> convolution.first_signal = [0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6]
+        >>> convolution.second_signal = [0.1, 0.3, 0.5, 0.7, 0.9, 1.1, 1.3, 1.5]
+        >>> convolution.circular_convolution()
+        [5.2, 6.0, 6.48, 6.64, 6.48, 6.0, 5.2, 4.08]
+
+        >>> convolution.first_signal = [-1, 1, 2, -2]
+        >>> convolution.second_signal = [0.5, 1, -1, 2, 0.75]
+        >>> convolution.circular_convolution()
+        [6.25, -3.0, 1.5, -2.0, -2.75]
+
+        >>> convolution.first_signal = [1, -1, 2, 3, -1]
+        >>> convolution.second_signal = [1, 2, 3]
+        >>> convolution.circular_convolution()
+        [8.0, -2.0, 3.0, 4.0, 11.0]
+
+        """
+
+        length_first_signal = len(self.first_signal)
+        length_second_signal = len(self.second_signal)
+
+        max_length = max(length_first_signal, length_second_signal)
+
+        # create a zero matrix of max_length x max_length
+        matrix = [[0] * max_length for i in range(max_length)]
+
+        # fills the smaller signal with zeros to make both signals of same length
+        if length_first_signal < length_second_signal:
+            self.first_signal += [0] * (max_length - length_first_signal)
+        elif length_first_signal > length_second_signal:
+            self.second_signal += [0] * (max_length - length_second_signal)
+
+        """
+        Fills the matrix in the following way assuming 'x' is the signal of length 4
+        [
+            [x[0], x[3], x[2], x[1]],
+            [x[1], x[0], x[3], x[2]],
+            [x[2], x[1], x[0], x[3]],
+            [x[3], x[2], x[1], x[0]]
+        ]
+        """
+        for i in range(max_length):
+            rotated_signal = deque(self.second_signal)
+            rotated_signal.rotate(i)
+            for j, item in enumerate(rotated_signal):
+                matrix[i][j] += item
+
+        # multiply the matrix with the first signal
+        final_signal = np.matmul(np.transpose(matrix), np.transpose(self.first_signal))
+
+        # rounding-off to two decimal places
+        return [float(round(i, 2)) for i in final_signal]
+
+
+if __name__ == "__main__":
+    doctest.testmod()

--- a/__sql6/knn.md
+++ b/__sql6/knn.md
@@ -1,0 +1,44 @@
+
+
+``` r
+library(knn)
+```
+
+```
+## Error in library(knn): there is no package called 'knn'
+```
+
+``` r
+x <- cbind(x_train,y_train)
+```
+
+```
+## Error in cbind(x_train, y_train): object 'x_train' not found
+```
+
+``` r
+# Fitting model
+fit <-knn(y_train ~ ., data = x,k=5)
+```
+
+```
+## Error in knn(y_train ~ ., data = x, k = 5): could not find function "knn"
+```
+
+``` r
+summary(fit)
+```
+
+```
+## Error in summary(fit): object 'fit' not found
+```
+
+``` r
+# Predict Output 
+predicted= predict(fit,x_test)
+```
+
+```
+## Error in predict(fit, x_test): object 'fit' not found
+```
+

--- a/__sql6/weight_conversion.jl
+++ b/__sql6/weight_conversion.jl
@@ -1,0 +1,37 @@
+KILOGRAM_CHART = Dict{String,Float64}(
+    "kilogram" => 1.0,
+    "gram" => 10^3,
+    "milligram" => 10^6,
+    "metric-ton" => 10^-3,
+    "long-ton" => 0.0009842073,
+    "short-ton" => 0.0011023122,
+    "pound" => 2.2046244202,
+    "ounce" => 35.273990723,
+    "carrat" => 5000.0,
+    "atomic-mass-unit" => 6.022136652e26,
+)
+
+WEIGHT_TYPE_CHART = Dict{String,Float64}(
+    "kilogram" => 1.0,
+    "gram" => 10^-3,
+    "milligram" => 10^-6,
+    "metric-ton" => 10^3,
+    "long-ton" => 1016.04608,
+    "short-ton" => 907.184,
+    "pound" => 0.453592,
+    "ounce" => 0.0283495,
+    "carrat" => 0.0002,
+    "atomic-mass-unit" => 1.660540199e-27,
+)
+
+function weight_conversion(value, from_type, to_type)
+    if !haskey(KILOGRAM_CHART, to_type) || !haskey(WEIGHT_TYPE_CHART, from_type)
+        throw(
+            error(
+                "Invalid 'from_type' or 'to_type' value: $(from_type), $(to_type)\n",
+                "Supported values are: $(WEIGHT_TYPE_CHART)",
+            ),
+        )
+    end
+    return value * KILOGRAM_CHART[to_type] * WEIGHT_TYPE_CHART[from_type]
+end


### PR DESCRIPTION
97 This issue has been marked as invalid because the described behavior is expected according to our data validation specifications. Files exceeding the configured row limit are intentionally rejected to prevent memory exhaustion, which is documented in our pipeline configuration guidelines.